### PR TITLE
Changing RStudio version comparison code to use string as comparison basis.

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -2,7 +2,7 @@
 check_available = function() {
   if (rstudioapi::isAvailable() == FALSE & getOption("is.job", FALSE) == FALSE)
     stop("You must run this from the RStudio main session.")
-  if (rstudioapi::getVersion() < 1.2)
+  if (rstudioapi::getVersion() < '1.2')
     stop("Install RStudio v1.2 or greater for the 'jobs' functionality.")
 
   invisible(TRUE)


### PR DESCRIPTION
Starting any job fails on R 4.4. I tested this on a Mac, a PC at my disposal, and also on Posit Cloud. Somehow it is the version comparison code that uses rstudioapi fails, and everything gets back to normal if I use a string version number when testing for Rstudio version >1.2. I verified that the issue is not present for R 4.3.0 on a Windows PC and R 4.3.3 on Posit Cloud. I also verified on the aforementioned platforms that code with my fix still does work. I'm not sure whether RStudio or the API would need to be fixed rather than this package, and also I'm aware that more extensive testing would be desirable, but I don't have the resources for that right now - I still found it more useful to post this as a pull request and not a comment, and I hope that's OK :)